### PR TITLE
Make test order consistent even when tests are added or removed.

### DIFF
--- a/random_plugin.py
+++ b/random_plugin.py
@@ -1,3 +1,4 @@
+import hashlib
 from itertools import groupby
 from random import Random
 import time
@@ -34,9 +35,13 @@ def pytest_collection_modifyitems(session, config, items):
     the items in-place."""
     if not config.option.random:
         return
-    random = Random()
-    random.seed(config.option.random_seed)
-    random.shuffle(items)
+    
+    seed = str(config.option.random_seed)
+    def key(item):
+        return hashlib.sha1(seed + item.name).digest()
+
+    items.sort(key=key)
+    
     if not config.option.random_group:
         return
     groups = {}


### PR DESCRIPTION
Often when tests have an order problem you want to remove tests to see
which two (or more) tests are causing the problem. However previously
adding or removing any tests would cause the order to completely change.
This change keeps the relative order of the tests the same to ease this
debugging.

@angelini @kmtaylor-github 
